### PR TITLE
fix(spec): require Codex MCP response ID as proof of execution

### DIFF
--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -99,9 +99,9 @@ Iterate based on review feedback for a maximum of 3 cycles. If fundamental issue
 
 1. Read the complete design from the plan file
 2. Call the `mcp__codex__codex` tool to submit the design for review
-3. **Capture the response ID** returned by Codex (format: `codex-[id]` or similar)
+3. **Capture the `sessionId`** from the response's `_meta` field (this is the Codex session identifier)
 4. Return to the parent agent with:
-   - The **response ID** (required — this proves the MCP was called)
+   - The **`sessionId`** (required — this proves the MCP was called)
    - Codex's feedback summary
    - Any critical issues that require design iteration
 
@@ -115,16 +115,16 @@ Submit this design for review:
 
 Focus areas: architectural concerns, potential issues, better alternatives, best practices alignment.
 
-IMPORTANT: Return the exact response ID from Codex along with the feedback. The response ID is required proof that the MCP was called.
+IMPORTANT: Extract and return the `sessionId` from the response's `_meta` field. This is required proof that the MCP was called and enables follow-up queries via `mcp__codex__codex-reply`.
 ```
 
-**Verification**: If the subagent returns without a valid Codex response ID, the review did not happen. Re-launch the subagent with explicit instructions to call `mcp__codex__codex` and return the response ID.
+**Verification**: If the subagent returns without a valid Codex `sessionId`, the review did not happen. Re-launch the subagent with explicit instructions to call `mcp__codex__codex` and return the `sessionId` from `_meta`.
 
 If Codex identifies significant issues, iterate on the design (counts toward the 3-cycle maximum). Minor suggestions can be noted for implementation.
 
-**Exit Plan Mode**: Once the design is complete and reviewed by both subagents, include the Codex response ID in your ExitPlanMode summary. This serves as:
+**Exit Plan Mode**: Once the design is complete and reviewed by both subagents, include the Codex `sessionId` in your ExitPlanMode summary. This serves as:
 - Proof that external review occurred
-- A reference for follow-up queries if needed during implementation
+- A reference for follow-up queries via `mcp__codex__codex-reply` if needed during implementation
 
 Use ExitPlanMode to get user approval before proceeding to implementation.
 
@@ -400,7 +400,7 @@ Alternative: Config file (JSON/YAML)
 Use the Task tool to launch subagents for:
 
 - **Design Review** (`general-purpose`): Required during Phase 1 to critically evaluate the design
-- **Plan Review via Codex** (`general-purpose`): REQUIRED during Phase 1 after design review; subagent MUST call `mcp__codex__codex` and return the response ID as proof of execution
+- **Plan Review via Codex** (`general-purpose`): REQUIRED during Phase 1 after design review; subagent MUST call `mcp__codex__codex` and return the `sessionId` as proof of execution
 - **Task Preparation** (`Explore`): For complex tasks before execution to analyze files and draft test cases
 - **Code Review** (`pr-review-toolkit:code-reviewer`): Non-trivial changes before committing; if plugin unavailable, use `general-purpose` with explicit review prompt
 - **Specification Writing** (`general-purpose`): Required for final documentation in Phase 4
@@ -418,7 +418,7 @@ Do not use subagents for:
 Before proceeding to the next phase:
 
 - Design review subagent finds no critical issues (minor issues acceptable after 3 iterations)
-- Codex MCP review completed with valid response ID captured (required proof of external review)
+- Codex MCP review completed with valid `sessionId` captured (required proof of external review)
 - All tests pass (if test infrastructure exists)
 - Code follows project conventions and passes code review
 - Documentation is updated and accurate

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -95,28 +95,38 @@ Write the design in the plan file, structured as "what" then "how":
 
 Iterate based on review feedback for a maximum of 3 cycles. If fundamental issues remain, use AskUserQuestion to resolve.
 
-**Plan Review (Codex)**: After the design review subagent completes, launch a general-purpose subagent (via Task tool with `subagent_type: "general-purpose"`) to get an external review using the Codex MCP server. The subagent should:
+**Plan Review (Codex)** — REQUIRED: After the design review subagent completes, you MUST launch a general-purpose subagent to get an external review from the Codex MCP server. This step cannot be skipped. The subagent must:
 
 1. Read the complete design from the plan file
-2. Use the `mcp__codex__codex` tool to submit the design for review with a prompt like:
+2. Call the `mcp__codex__codex` tool to submit the design for review
+3. **Capture the response ID** returned by Codex (format: `codex-[id]` or similar)
+4. Return to the parent agent with:
+   - The **response ID** (required — this proves the MCP was called)
+   - Codex's feedback summary
+   - Any critical issues that require design iteration
 
-   ```
-   Review this design plan and provide critical feedback:
+Example prompt for the subagent:
 
-   [design content]
+```
+You MUST call the mcp__codex__codex tool to review this design. Do NOT skip this step or simulate the response.
 
-   Focus on: architectural concerns, potential issues, better alternatives, and best practices alignment. Be specific and actionable.
-   ```
+Submit this design for review:
+[design content]
 
-3. Return Codex's feedback, highlighting:
-   - Architectural concerns or anti-patterns
-   - Suggested improvements to the approach
-   - Potential issues with dependencies, performance, or maintainability
-   - Whether the design follows best practices for the technology stack
+Focus areas: architectural concerns, potential issues, better alternatives, best practices alignment.
 
-If Codex identifies significant issues, iterate on the design (this counts toward the 3-cycle maximum). Minor suggestions can be noted for consideration during implementation.
+IMPORTANT: Return the exact response ID from Codex along with the feedback. The response ID is required proof that the MCP was called.
+```
 
-**Exit Plan Mode**: Once the design is complete and reviewed (by both the internal subagent and Codex), use ExitPlanMode to get user approval before proceeding to implementation.
+**Verification**: If the subagent returns without a valid Codex response ID, the review did not happen. Re-launch the subagent with explicit instructions to call `mcp__codex__codex` and return the response ID.
+
+If Codex identifies significant issues, iterate on the design (counts toward the 3-cycle maximum). Minor suggestions can be noted for implementation.
+
+**Exit Plan Mode**: Once the design is complete and reviewed by both subagents, include the Codex response ID in your ExitPlanMode summary. This serves as:
+- Proof that external review occurred
+- A reference for follow-up queries if needed during implementation
+
+Use ExitPlanMode to get user approval before proceeding to implementation.
 
 ### Phase 2: Task Creation and Preparation — Post-Approval
 
@@ -390,7 +400,7 @@ Alternative: Config file (JSON/YAML)
 Use the Task tool to launch subagents for:
 
 - **Design Review** (`general-purpose`): Required during Phase 1 to critically evaluate the design
-- **Plan Review via Codex** (`general-purpose`): Required during Phase 1 after design review; subagent uses `mcp__codex__codex` tool to get external architectural feedback
+- **Plan Review via Codex** (`general-purpose`): REQUIRED during Phase 1 after design review; subagent MUST call `mcp__codex__codex` and return the response ID as proof of execution
 - **Task Preparation** (`Explore`): For complex tasks before execution to analyze files and draft test cases
 - **Code Review** (`pr-review-toolkit:code-reviewer`): Non-trivial changes before committing; if plugin unavailable, use `general-purpose` with explicit review prompt
 - **Specification Writing** (`general-purpose`): Required for final documentation in Phase 4
@@ -408,6 +418,7 @@ Do not use subagents for:
 Before proceeding to the next phase:
 
 - Design review subagent finds no critical issues (minor issues acceptable after 3 iterations)
+- Codex MCP review completed with valid response ID captured (required proof of external review)
 - All tests pass (if test infrastructure exists)
 - Code follows project conventions and passes code review
 - Documentation is updated and accurate

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -118,7 +118,16 @@ Focus areas: architectural concerns, potential issues, better alternatives, best
 IMPORTANT: Extract and return the `sessionId` from the response's `_meta` field. This is required proof that the MCP was called and enables follow-up queries via `mcp__codex__codex-reply`.
 ```
 
-**Verification**: If the subagent returns without a valid Codex `sessionId`, the review did not happen. Re-launch the subagent with explicit instructions to call `mcp__codex__codex` and return the `sessionId` from `_meta`.
+**Verification**: If the subagent returns without a valid Codex `sessionId`:
+1. First attempt: Re-launch the subagent with explicit instructions to call `mcp__codex__codex` and return the `sessionId` from `_meta`
+2. Second attempt failed: Report the failure to the user via AskUserQuestion with context about what went wrong (MCP unavailable, timeout, malformed response, etc.)
+
+Do NOT retry indefinitely. Two attempts maximum, then escalate.
+
+**Error Handling**: If the Codex MCP call fails (tool not available, timeout, error response):
+- The subagent should return immediately with the error details
+- Do not wait indefinitely for a response that won't come
+- Report: "Codex MCP review failed: [error]. Proceeding requires user decision."
 
 If Codex identifies significant issues, iterate on the design (counts toward the 3-cycle maximum). Minor suggestions can be noted for implementation.
 
@@ -418,7 +427,7 @@ Do not use subagents for:
 Before proceeding to the next phase:
 
 - Design review subagent finds no critical issues (minor issues acceptable after 3 iterations)
-- Codex MCP review completed with valid `sessionId` captured (required proof of external review)
+- Codex MCP review completed with valid `sessionId` captured, OR user explicitly approved skipping due to MCP failure
 - All tests pass (if test infrastructure exists)
 - Code follows project conventions and passes code review
 - Documentation is updated and accurate


### PR DESCRIPTION
Addresses two issues observed during testing:
1. Agents skipping the Codex review step
2. Uncertainty about whether MCP was actually called vs mocked

Changes:
- Make Plan Review step explicitly REQUIRED (cannot be skipped)
- Require subagent to capture and return Codex response ID
- Add verification step: re-launch if no response ID returned
- Include response ID in ExitPlanMode summary as proof
- Add response ID check to Quality Standards

The response ID serves as:
- Proof that the MCP was actually called
- Reference for follow-up queries during implementation

https://claude.ai/code/session_014B3K9xZzL9QiFd7Y2Zrx51