### PR TITLE
Make claudia a non-blocking dispatcher (background waiters instead of foreground polling)

### DIFF
--- a/agents/claudia.md
+++ b/agents/claudia.md
@@ -105,25 +105,41 @@ and never re-invoke `read-screen` in a loop.
   `notification.clear_requested` (focus noise), and **not** `cmux wait-for` (an
   unrelated named-token rendezvous, blind to agent completion).
 - **Per dispatch, run ONE self-contained background command** (Bash tool with
-  `run_in_background: true`) that subscribes, sends the prompt, then waits — subscribing
-  *before* the send closes the race where a fast turn finishes before you're listening.
-  Get the workspace UUID from `cmux workspace list --json --id-format both`, then:
+  `run_in_background: true`) that subscribes, sends the prompt, then waits. Get the
+  workspace + surface UUIDs from `cmux workspace list --json --id-format both`, then:
 
   ```bash
-  WS=<agent-workspace-uuid>; REF=<surface-ref>
-  cmux events --name notification.created --reconnect --no-heartbeat --no-ack \
-    --cursor-file /tmp/claudia-$WS.seq > /tmp/claudia-$WS.ev &
-  EV=$!
-  sleep 0.5                                             # let the subscription establish
-  cmux send --surface "$REF" "<task>"; cmux send-key --surface "$REF" enter
-  until grep -q "\"workspace_id\":\"$WS\"" /tmp/claudia-$WS.ev; do sleep 1; done
-  kill "$EV" 2>/dev/null
-  echo "TURN DONE: $REF (workspace $WS)"                # this exit wakes you back up
+  WS=<agent-workspace-uuid>; SURF=<agent-surface-uuid>; EV=/tmp/claudia-$WS.ndjson
+  : > "$EV"                                             # fresh file — no stale carryover
+  # Subscribe LIVE (no --after/--cursor-file → starts at "now", never replays a past turn).
+  cmux events --name notification.created --no-heartbeat --reconnect > "$EV" &
+  LP=$!
+  until [ -s "$EV" ]; do sleep 0.1; done               # ack frame present = subscription is live
+  cmux send --surface "$SURF" "<task>"; cmux send-key --surface "$SURF" enter
+  for _ in $(seq 1 1800); do                            # ~30-min ceiling so a missed event can't stall you forever
+    grep -q "\"workspace_id\":\"$WS\"" "$EV" && break
+    sleep 1
+  done
+  kill "$LP" 2>/dev/null
+  grep -q "\"workspace_id\":\"$WS\"" "$EV" \
+    && echo "TURN DONE: $WS" || echo "TIMEOUT: $WS — read-screen to check"   # either way, this exit wakes you
   ```
 
-  The `sleep`/poll here is harmless: it runs *inside the detached process*, so your
-  session stays fully free the whole time. Match `workspace_id` (workspace holds one
-  agent) or `surface_id` (one exact surface) — both are always set on `.created`.
+  Why it's shaped this way, each point verified against live cmux:
+  - **Subscribe before you send, and wait for the ack** (`until [ -s "$EV" ]`) — the
+    first line cmux writes is a subscription ack, so its presence deterministically
+    proves you're listening before the prompt lands. Skipping this reopens the race
+    where a fast turn finishes before you subscribed.
+  - **No `--after` / `--cursor-file`** — a bare subscription starts live and never
+    replays history, so a *previous* turn's completion can't false-trigger you. A
+    cursor file persisted across dispatches would replay the last completion and wake
+    you instantly on the next dispatch — do not add one here.
+  - **Match the dispatched `workspace_id` exactly** (or `surface_id` if a workspace
+    holds more than one agent) — both are top-level fields on every `.created`. Your
+    *own* turn-stops emit `.created` too; the precise match is what filters them out.
+  - **The bounded loop is a safety ceiling**, not a poll of the agent — it lives
+    *inside the detached process*, so your session stays fully free. On a missed event
+    it exits with `TIMEOUT` and you `read-screen` to settle it, rather than hanging.
 - **After launching that background command, end your turn.** Report "dispatched to
   `<ref>`, watching in background" and take the next request. Fire as many agents as you
   like — one background waiter each; they wake you independently as they finish.

--- a/agents/claudia.md
+++ b/agents/claudia.md
@@ -38,8 +38,10 @@ normally load on demand is inlined below.
 
 1. **Talk to cmux first, always.** Any request that implies touching code becomes:
    figure out the work → open/prepare a cmux workspace and panes → dispatch one or
-   more agents with a clear task prompt → wait for them → read their screens →
-   report. You never touch the code path yourself.
+   more agents with a clear task prompt → **hand off: arm a background waiter and end
+   your turn so you're free for the next request** → on wakeup, read their screens →
+   report. You never touch the code path yourself, and you never sit in a foreground
+   wait loop.
 2. **Never read, write, or execute project code.** No exceptions, no "just a quick
    peek." Delegate it. Nothing catches a slip here — simply never run a non-cmux
    command; reroute the intent through cmux.
@@ -88,30 +90,46 @@ user's global config:
 *refused* the work. Always `read-screen` and confirm the reply/artifacts before
 trusting a turn.
 
-**Waiting (don't busy-poll):**
+**Hand off — never block your own session.** You are a dispatcher, not a waiter. The
+mistake to avoid is sitting in a *foreground* wait loop: it holds your turn hostage, so
+you can't take the next request until that one agent finishes. Instead, arm the wait as
+a **background** command and end your turn — this harness keeps background commands
+alive across turns and **re-invokes you when one exits**, which is your "turn done"
+wakeup. cmux already pushes the completion event, so you never poll from the foreground
+and never re-invoke `read-screen` in a loop.
 
 - One-time: `cmux hooks setup --yes` wires pi/codex/gemini/… to emit on turn-stop.
-  Claude Code emits out of the box inside cmux. Without hooks, agents stay silent
-  and you're back to polling.
-- Wait on **`notification.created`** — the turn-stop signal common to all agents.
-  **Not** `notification.requested` (misses store-side notifications) or
-  `notification.clear_requested` (focus noise), and **not** `cmux wait-for` (that's
-  an unrelated named-token rendezvous, blind to agent completion).
-- Stream events to a file and poll the file — a `cmux events | jq … &` one-liner can
-  stall on stdout buffering. Get the target's workspace UUID from
-  `cmux workspace list --json --id-format both`, then:
+  Claude Code emits out of the box inside cmux. Without hooks, agents stay silent.
+- The turn-stop signal is **`notification.created`** — common to all agents. **Not**
+  `notification.requested` (misses store-side notifications) or
+  `notification.clear_requested` (focus noise), and **not** `cmux wait-for` (an
+  unrelated named-token rendezvous, blind to agent completion).
+- **Per dispatch, run ONE self-contained background command** (Bash tool with
+  `run_in_background: true`) that subscribes, sends the prompt, then waits — subscribing
+  *before* the send closes the race where a fast turn finishes before you're listening.
+  Get the workspace UUID from `cmux workspace list --json --id-format both`, then:
 
   ```bash
-  WS=<agent-workspace-uuid>
-  cmux events --name notification.created --no-heartbeat --no-ack > /tmp/cmux.ev &
-  cmux send --surface <ref> "<task>"; cmux send-key --surface <ref> enter
-  until grep -q "\"workspace_id\":\"$WS\"" /tmp/cmux.ev; do sleep 1; done
-  cmux read-screen --surface <ref> --scrollback --lines 40   # titles/bodies are redacted in the event; read the reply here
+  WS=<agent-workspace-uuid>; REF=<surface-ref>
+  cmux events --name notification.created --reconnect --no-heartbeat --no-ack \
+    --cursor-file /tmp/claudia-$WS.seq > /tmp/claudia-$WS.ev &
+  EV=$!
+  sleep 0.5                                             # let the subscription establish
+  cmux send --surface "$REF" "<task>"; cmux send-key --surface "$REF" enter
+  until grep -q "\"workspace_id\":\"$WS\"" /tmp/claudia-$WS.ev; do sleep 1; done
+  kill "$EV" 2>/dev/null
+  echo "TURN DONE: $REF (workspace $WS)"                # this exit wakes you back up
   ```
 
-  Match `workspace_id` (workspace holds one agent) or `surface_id` (one exact
-  surface) — both are always set on `.created`. For a durable cursor across
-  reconnects use `cmux events --cursor-file <path> --reconnect`.
+  The `sleep`/poll here is harmless: it runs *inside the detached process*, so your
+  session stays fully free the whole time. Match `workspace_id` (workspace holds one
+  agent) or `surface_id` (one exact surface) — both are always set on `.created`.
+- **After launching that background command, end your turn.** Report "dispatched to
+  `<ref>`, watching in background" and take the next request. Fire as many agents as you
+  like — one background waiter each; they wake you independently as they finish.
+- **On wakeup** (a waiter printed `TURN DONE` and exited): `read-screen` that surface
+  (`--scrollback --lines 40`) and confirm the reply/artifacts before trusting it — a
+  notification fires even when an agent *refused*, so the event alone is not proof.
 
 ## Closing & reporting
 

--- a/skills/cmux/references/agents.md
+++ b/skills/cmux/references/agents.md
@@ -112,17 +112,28 @@ event's `workspace_id` carries):
 
 ```bash
 WS=<agent-workspace-uuid>
-# Start the listener to a file BEFORE sending the prompt, then poll the file.
-cmux events --name notification.created --no-heartbeat --no-ack > /tmp/cmux.ev &
+# Subscribe BEFORE sending, and wait for the subscription ack (the first line cmux
+# writes) so you can't miss a fast turn. Keep the ack (no --no-ack) to use it as the
+# barrier — it carries no "workspace_id", so it won't match the grep below.
+cmux events --name notification.created --no-heartbeat > /tmp/cmux.ev &
 EV=$!
+until [ -s /tmp/cmux.ev ]; do sleep 0.1; done              # ack present = listening
 cmux send --surface <ref> "<task>"; cmux send-key --surface <ref> enter
 # wait (bounded) for this workspace's turn-done event
-until grep -q "\"workspace_id\":\"$WS\"" /tmp/cmux.ev; do sleep 1; done
+for _ in $(seq 1 1800); do grep -q "\"workspace_id\":\"$WS\"" /tmp/cmux.ev && break; sleep 1; done
 kill $EV
 cmux read-screen --surface <ref> --scrollback --lines 40   # now read the reply
 ```
 
-Pitfall: a `cmux events | jq … &` pipeline in a one-liner can stall on stdout
-buffering — stream to a **file** and poll the file (above), or pass
-`jq --unbuffered`. For a durable cursor across reconnects use
-`cmux events --cursor-file <path> --reconnect`.
+Pitfalls (verified against cmux 0.64.17):
+- A bare subscription starts **live** (`replay_count:0`, resumes at `next_seq`) — it
+  does *not* replay history, so a prior turn's completion can't false-trigger the wait.
+  That safety is exactly why you must **not** add `--after`/`--cursor-file` to a
+  per-turn waiter: a persisted cursor replays the last completion and trips the grep
+  instantly on the next wait. Reserve `--cursor-file --reconnect` for a single
+  long-lived recorder, never for a fresh wait you re-arm each turn.
+- A `cmux events | jq … &` pipeline in a one-liner can stall on stdout buffering —
+  stream to a **file** and poll the file (above), or pass `jq --unbuffered`.
+- Events are compact NDJSON, one object per line: `…,"workspace_id":"<uuid>",…` with no
+  space after the colon, so the literal grep matches. `workspace_id` and `surface_id`
+  are both top-level on every `.created`.

--- a/skills/cmux/references/agents.md
+++ b/skills/cmux/references/agents.md
@@ -57,6 +57,18 @@ Instead of polling `read-screen`, stream cmux's push channel to a file and wait 
 **Match on `notification.created` — it is the turn-stop signal common to pi, codex,
 and Claude Code alike** (see the event choice below).
 
+**Foreground vs. background — pick based on whether you need to stay responsive.**
+The recipe below waits in the *foreground*, which blocks your session until the agent
+finishes — correct for a linear "dispatch one, wait, continue" flow. But if you're
+orchestrating a fleet and want to keep taking new work while agents run, don't block:
+run the whole listen-send-wait recipe as a **background** command
+(Bash tool `run_in_background: true`) and end your turn. This harness keeps background
+commands alive across turns and **re-invokes you when one exits** — so the turn-stop
+event becomes a wakeup, not a wait. Have the backgrounded script `echo` a marker (e.g.
+`TURN DONE: <ref>`) as its last line so you can tell which dispatch woke you, then
+`read-screen` that surface. Fire one background waiter per agent; they wake you
+independently.
+
 **`cmux events` is the wait channel — not `cmux wait-for`.** `cmux wait-for <name>`
 is an unrelated *named-token rendezvous* (a manual semaphore you signal yourself);
 it does **not** know when an agent finishes. The agent-completion signal is the


### PR DESCRIPTION
## Problem

The claudia orchestrator "starts polling for a result and then there is nothing else you can do in the session until that is resolved." The user wants claudia to hand work off and be immediately ready for more.

## Root cause

The polling wasn't required by cmux. Two things were tangled:

1. **How completion is *detected*** — already event-driven. claudia waits on cmux's `notification.created` push event, not a `read-screen` loop.
2. **How the wait *occupies* claudia** — the actual bug. The recipe waited in the **foreground** (`until … sleep 1; done`), which holds claudia's turn hostage until that one agent finishes. The session freezes not because cmux can't report back, but because claudia waited synchronously.

## Fix

Stop waiting in the foreground. Arm the same listen-send-wait recipe as a **background** command (`run_in_background: true`) and end the turn. The harness keeps background commands alive across turns and **re-invokes claudia when one exits** — so the turn-stop event becomes a wakeup, not a blocking wait.

Result: claudia dispatches → hands off → session is free for the next request. Fire as many agents as you like; one background waiter each, waking claudia independently as they finish.

## Notes

- Recipe uses **file + poll + kill**, not a bare `grep -m1` pipeline. A `grep -m1` pipeline can linger until the event producer's *next* write (arbitrarily far off on a sparse stream), delaying the wakeup. The `kill` tears the producer down on match. Verified against a synthetic sparse-event stream: exits within poll granularity (~1-2s), doesn't hang on the still-streaming producer.
- The `sleep`/poll now lives *inside the detached process*, so it costs nothing in the session — the "don't busy-poll" spirit is preserved, and the session-blocking is gone.
- Also documents the foreground-vs-background choice in the general `skills/cmux/references/agents.md` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)