### PR TITLE
Add fable agent (claude alias) to cmux skill and claudia

### DIFF
--- a/agents/claudia.md
+++ b/agents/claudia.md
@@ -3,7 +3,7 @@ name: claudia
 description: >-
   cmux orchestrator. Plans and coordinates work, then delegates everything that
   touches a codebase — reading, writing, running, testing, debugging — to agent
-  sessions (Claude Code, Codex, pi) spawned inside cmux. Never reads, writes, or
+  sessions (Claude Code, Codex, pi, fable) spawned inside cmux. Never reads, writes, or
   executes project code itself. Launch as the top-level session with
   `claude --agent claudia`.
 tools: Bash
@@ -69,7 +69,7 @@ Follow the preloaded **cmux** skill. In short:
 
 ## Launching & waiting on agents inside cmux (inlined reference)
 
-Only relevant when a pane hosts a coding agent (Claude Code, Codex, pi). Plain
+Only relevant when a pane hosts a coding agent (Claude Code, Codex, pi, fable). Plain
 terminal/browser surfaces don't need any of this.
 
 **Launch unattended, from inside the pane** via `cmux send` + `cmux send-key … enter`
@@ -80,6 +80,9 @@ user's global config:
 - **Claude Code:** `claude --dangerously-skip-permissions "<task>"`. Plain `claude`
   launches in ask-for-permission mode — it will *decline* Bash/edits, print
   instructions, and end its turn. Bypass is its yolo equivalent.
+- **fable:** `fable --dangerously-skip-permissions "<task>"`. A user alias for
+  `claude` — it *is* Claude Code, takes the same flags, and emits notifications out of
+  the box. Launch and wait on it exactly as Claude Code.
 - **Codex:** `codex -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox "<task>"`
   (yolo, default for hands-off runs) or `codex --full-auto "<task>"` (sandboxed).
   `gpt-5.5` is the default and isn't validated by cmux — if Codex rejects it,

--- a/agents/claudia.md
+++ b/agents/claudia.md
@@ -80,9 +80,10 @@ user's global config:
 - **Claude Code:** `claude --dangerously-skip-permissions "<task>"`. Plain `claude`
   launches in ask-for-permission mode — it will *decline* Bash/edits, print
   instructions, and end its turn. Bypass is its yolo equivalent.
-- **fable:** `fable --dangerously-skip-permissions "<task>"`. A user alias for
-  `claude` — it *is* Claude Code, takes the same flags, and emits notifications out of
-  the box. Launch and wait on it exactly as Claude Code.
+- **fable:** `fable --dangerously-skip-permissions "<task>"`. A user alias for `claude`
+  against a separate config dir (`~/.claude-fable`) — still Claude Code, but a distinct,
+  independently-authenticated identity for running a second Claude in parallel. Same
+  flags and out-of-the-box notifications; launch and wait on it exactly as Claude Code.
 - **Codex:** `codex -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox "<task>"`
   (yolo, default for hands-off runs) or `codex --full-auto "<task>"` (sandboxed).
   `gpt-5.5` is the default and isn't validated by cmux — if Codex rejects it,

--- a/skills/cmux/SKILL.md
+++ b/skills/cmux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux
-description: Drive cmux from natural language — spawn, prompt, read, and tear down its windows, workspaces, panes, and surfaces, and orchestrate the agent sessions (Claude Code, Codex, pi) running inside them. Use whenever a prompt asks to open, inspect, drive, or close cmux surfaces or run agents in them.
+description: Drive cmux from natural language — spawn, prompt, read, and tear down its windows, workspaces, panes, and surfaces, and orchestrate the agent sessions (Claude Code, Codex, pi, fable) running inside them. Use whenever a prompt asks to open, inspect, drive, or close cmux surfaces or run agents in them.
 argument-hint: [what to do in cmux]
 ---
 
@@ -54,7 +54,7 @@ cmux workspace create --name <name> --cwd <dir> --env-file .env --json
 
 - **`cmux workspace create` supports `--env-file`, which loads that file's
   environment variables into every surface in the workspace** — so an agent
-  launched in a pane (`claude`, `pi`, `codex`, `gemini`) comes up already
+  launched in a pane (`claude`, `fable`, `pi`, `codex`, `gemini`) comes up already
   authenticated, no manual `export` needed.
 - **Default `--env-file` to `.env`** (the repo's `.env`) unless told otherwise:
   `--env-file .env`. That is the canonical source for `OPENROUTER_API_KEY`,
@@ -86,7 +86,7 @@ You operate surfaces the way a person would, but over the CLI:
 
 ### Driving AI agents inside cmux
 
-cmux surfaces can host coding agents (Claude Code, Codex, pi). Launching them so they
+cmux surfaces can host coding agents (Claude Code, Codex, pi, fable). Launching them so they
 run unattended, and waiting on their turn-completion via notification events, have
 agent-specific gotchas — bypass/yolo launch flags, one-time hook setup, and which
 event actually signals "done". **Before you launch or wait on any agent, read

--- a/skills/cmux/references/agents.md
+++ b/skills/cmux/references/agents.md
@@ -52,8 +52,11 @@ the reply or the artifacts before trusting the turn.
 
 ### fable
 
-`fable` is a custom user alias that points at `claude` — so it *is* Claude Code and
-behaves identically. Launch it in bypass mode exactly like `cc`:
+`fable` is a custom user alias for `claude` running against a **separate config dir**
+(`CLAUDE_CONFIG_DIR=~/.claude-fable`) — so it *is* Claude Code, but a distinct,
+independently-authenticated identity. Reach for it to run a second Claude session in
+parallel with `claude` without the two sharing auth/session state. Launch it in bypass
+mode exactly like `cc`:
 
 - **fable bypass:** `fable --dangerously-skip-permissions "<task>"` — same yolo
   semantics as `claude --dangerously-skip-permissions`. It accepts every `claude`

--- a/skills/cmux/references/agents.md
+++ b/skills/cmux/references/agents.md
@@ -1,6 +1,6 @@
 # Driving AI agents inside cmux
 
-Read this when a task involves **launching** a coding agent (Claude Code, Codex, pi)
+Read this when a task involves **launching** a coding agent (Claude Code, Codex, pi, fable)
 in a cmux surface, or **waiting** for one to finish its turn. For plain
 terminal/browser surfaces none of this applies — the core control loop in `SKILL.md`
 is enough.
@@ -49,6 +49,21 @@ Caveat verified in testing: a notification fires on turn-completion **even when 
 refused to do the work** — a bare event is not proof of success. So the `read-screen`
 step in **Waiting for an agent's turn to finish** (below) isn't optional here: confirm
 the reply or the artifacts before trusting the turn.
+
+### fable
+
+`fable` is a custom user alias that points at `claude` — so it *is* Claude Code and
+behaves identically. Launch it in bypass mode exactly like `cc`:
+
+- **fable bypass:** `fable --dangerously-skip-permissions "<task>"` — same yolo
+  semantics as `claude --dangerously-skip-permissions`. It accepts every `claude`
+  flag, and emits `notification.created` on turn-stop out of the box (no `cmux hooks`
+  entry needed), so wait on it exactly as you would Claude Code. The "notification ≠
+  success" caveat above applies unchanged — `read-screen` and confirm.
+
+Because it's a shell alias, it resolves only in the pane's interactive shell — which
+is where `cmux send` types it, so it works there. It would *not* resolve from a
+non-interactive batch shell, but you never launch agents that way anyway.
 
 ## Waiting for an agent's turn to finish (don't busy-poll)
 


### PR DESCRIPTION
`fable` is a custom user alias that points at `claude`, so it *is* Claude Code — same flags (`--dangerously-skip-permissions`), same out-of-the-box `notification.created` turn-stop signal.

## Changes
- **`skills/cmux/references/agents.md`** — add a `### fable` subsection (bypass launch, notification behavior, the shell-alias-resolves-in-the-pane caveat) and add fable to the roster line.
- **`skills/cmux/SKILL.md`** — add fable to the skill description, the env-file agent list, and the "Driving AI agents" roster.
- **`agents/claudia.md`** — add fable to the roster lines and a launch bullet under "Launching & waiting on agents".

🤖 Generated with [Claude Code](https://claude.com/claude-code)